### PR TITLE
Fix slice

### DIFF
--- a/python-package/xgboost/core.py
+++ b/python-package/xgboost/core.py
@@ -611,12 +611,13 @@ class DMatrix(object):
         res : DMatrix
             A new DMatrix containing only selected indices.
         """
-        res = DMatrix(None, feature_names=self.feature_names)
+        res = DMatrix(None)
         res.handle = ctypes.c_void_p()
         _check_call(_LIB.XGDMatrixSliceDMatrix(self.handle,
                                                c_array(ctypes.c_int, rindex),
                                                c_bst_ulong(len(rindex)),
                                                ctypes.byref(res.handle)))
+        res.feature_names=self.feature_names
         return res
 
     @property


### PR DESCRIPTION
It's useless to pass feature_names as parameter to DMatrix(None) constructor. But it totally makes sense to do it just before the function ends.